### PR TITLE
Fix: Day 3 slides URL

### DIFF
--- a/2025/day3.md
+++ b/2025/day3.md
@@ -1,7 +1,6 @@
 # Day 3 – Interacting with hardware: buttons and leds
 
-Slides: [day3_slides](./day3_slides)
-
+Slides: [day3_slides](./slides/slides_day3.pdf)
 ## Description
 
 This lab introduces students to the fundamentals of Linux kernel GPIO drivers through a


### PR DESCRIPTION
Update Day 3 slides link to correct PDF path https://linux-kernel-summer-school.github.io/docs/2025/day3_slides are throwing an 404 error(not available).